### PR TITLE
Fix focus after load only when auto-focus is true

### DIFF
--- a/src/core/main/ts/focus/EditorFocus.ts
+++ b/src/core/main/ts/focus/EditorFocus.ts
@@ -108,7 +108,9 @@ const focusEditor = (editor: Editor) => {
     // WebKit needs this call to fire focusin event properly see #5948
     // But Opera pre Blink engine will produce an empty selection so skip Opera
     if (!Env.opera) {
-      focusBody(body);
+      if (editor.settings.auto_focus === true) {
+           focusBody(body);
+      }
     }
 
     editor.getWin().focus();

--- a/src/core/main/ts/init/InitContentBody.ts
+++ b/src/core/main/ts/init/InitContentBody.ts
@@ -27,6 +27,7 @@ import Delay from '../api/util/Delay';
 import Quirks from '../util/Quirks';
 import Tools from '../api/util/Tools';
 import { Editor } from 'tinymce/core/api/Editor';
+import EditorFocus from '../focus/EditorFocus';
 import * as MultiClickSelection from 'tinymce/core/selection/MultiClickSelection';
 import * as DetailsElement from '../selection/DetailsElement';
 import { document, window } from '@ephox/dom-globals';
@@ -135,7 +136,9 @@ const autoFocus = function (editor: Editor) {
       }
 
       if (!focusEditor.destroyed) {
-        focusEditor.focus();
+         if (!EditorFocus.hasFocus(focusEditor)) {
+            EditorFocus.focus(focusEditor , false);
+         }
       }
     }, 100);
   }


### PR DESCRIPTION
The editor always focused (no matter what the auto_focus value is).
now, the editor is focused only when the auto_focus is true.